### PR TITLE
use Fortran 200X argument count function instead of GCC extension

### DIFF
--- a/src/utils.f90
+++ b/src/utils.f90
@@ -44,6 +44,7 @@ MODULE utils_module
     CHARACTER(LEN=64) :: arg
 
     INTEGER(i_knd) :: narg, n
+
 !_______________________________________________________________________
 !
 !   Return if not root. Loop over the first two command line arguments
@@ -57,7 +58,7 @@ MODULE utils_module
 
     narg = COMMAND_ARGUMENT_COUNT ( )
 
-    IF ( narg /= 2 ) THEN
+    IF ( COMMAND_ARGUMENT_COUNT() < 2 ) THEN
       ierr = 1
       error = '***ERROR: CMDARG: Missing command line entry'
       RETURN


### PR DESCRIPTION
`GET_COMMAND_ARGUMENT` is already used, so there is no reason not to use the Fortran 2003 intrinsic `COMMAND_ARGUMENT_COUNT` instead of `IARGC`.