### PR TITLE
Adding CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+################################################################################
+#
+# CMakeLists.txt
+# 
+# Author: Anthony Cabrera:
+# Contact: cabreraam AT ieee DOT org
+# Description: CMakeLists.txt replacement for SNAP Makefile
+#
+################################################################################
+
+cmake_minimum_required(VERSION 3.18)
+
+project(snap_test)
+
+# Direct CMake to a specific MPI implementation. Specify
+# -DMPI_EXECUTABLE_SUFFIX=.mpich for MPICH MPI implementation 
+set(MPI_EXECUTABLE_SUFFIX "" CACHE STRING "Direct CMake to a specific MPI implementation")
+
+enable_language(Fortran)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+add_subdirectory(src)

--- a/qasnap/mms_src/2d_mms_st.inp
+++ b/qasnap/mms_src/2d_mms_st.inp
@@ -1,7 +1,7 @@
 ! Input from namelist
 &invar
   nthreads=4
-  npey=4
+  npey=1
   ndimen=2
   nx=20
   lx=0.2

--- a/qasnap/mms_src/2d_mms_st.inp
+++ b/qasnap/mms_src/2d_mms_st.inp
@@ -1,7 +1,7 @@
 ! Input from namelist
 &invar
   nthreads=4
-  npey=1
+  npey=4
   ndimen=2
   nx=20
   lx=0.2

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,8 +226,8 @@ target_sources(snap
 target_compile_options(snap 
 	PRIVATE
 		$<$<Fortran_COMPILER_ID:GNU>:${SNAP_COMPILER_OPTIONS_GNU}>
-  	$<$<AND:$<Fortran_COMPILER_ID:Intel>,$<NOT:$<BOOL:${KNL}>>>:${SNAP_COMPILER_OPTIONS_IFORT}>
-  	$<$<AND:$<Fortran_COMPILER_ID:Intel>,$<BOOL:${KNL}>>:${SNAP_COMPILER_OPTIONS_IFORT_KNL}>
+		$<$<AND:$<Fortran_COMPILER_ID:Intel>,$<NOT:$<BOOL:${KNL}>>>:${SNAP_COMPILER_OPTIONS_IFORT}>
+		$<$<AND:$<Fortran_COMPILER_ID:Intel>,$<BOOL:${KNL}>>:${SNAP_COMPILER_OPTIONS_IFORT_KNL}>
 		$<$<Fortran_COMPILER_ID:IntelLLVM>:${SNAP_COMPILER_OPTIONS_IFX}>
 )
 target_compile_definitions(snap
@@ -288,8 +288,7 @@ add_custom_command(
 	COMMAND
 		cmake -E cat ${CMAKE_CURRENT_BINARY_DIR}/src_list.txt
 	COMMAND
-	#bash -c "while read file; do for word in $file; do ./LineCount $file Lines; done"
-	bash -c "while read line; do \
+		bash -c "while read line; do \
 			for file in $line; do \
 				${CMAKE_CURRENT_BINARY_DIR}/LineCount ${CMAKE_CURRENT_SOURCE_DIR}/$file	${CMAKE_CURRENT_BINARY_DIR}/Lines; \
 			done; \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,12 +8,6 @@
 #
 ################################################################################
 
-#cmake_minimum_required(VERSION 3.18)
-
-#project(snap_test)
-
-#enable_language(Fortran)
-
 ################################################################################
 #
 # Options and Variables
@@ -52,13 +46,6 @@ if(OPENMP)
 	message(STATUS "OpenMP_Fortran_LIBRARIES - ${OpenMP_Fortran_LIBRARIES}")
 	message(STATUS "OpenMP_HOME - ${OpenMP_HOME}")
 endif()
-
-#set(MPI "" CACHE STRING "Configure MPI")
-#set(FFLAGS "" CACHE STRING "Fortran flags")
-#set(FFLAG2 "" CACHE STRING "Fortran flags 2?")
-#set(DEFS "" CACHE STRING "Compiler definitions")
-#set(PPFLAGS "" CACHE STRING "Preprocessor flags?")
-#set(FORTRAN "" CACHE STRING "Fortran compiler")
 
 # Compiler Preprocessor Definitions
 # These should be passed in at the command line as a semi-colon-separated list
@@ -176,39 +163,9 @@ set(SNAP_COMPILER_OPTIONS_IFX
 	"Compiler options when ifx compiler detected"
 )
 
-# Compile Options for Classic Flang
-# TODO: What would the actual flags be for Classic Flang?
-set(SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_OPT
-	"-O3" 
-	CACHE 
-	STRING 
-	"Classic Flang compiler options when OPT=ON"
-)
-set(SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_NOT_OPT
-	"-O0"
-	"-g "
-	"-check bounds"
-	"-traceback"
-	"-warn unused"
-	CACHE 
-	STRING 
-	"Classic Flang compiler options when OPT=OFF"
-)
-set(SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_OPT
-	$<$<BOOL:${OPENMP}>:-fopenmp>
-	$<IF:$<BOOL:${OPT}>,${SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_OPT},${SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_OPT}>
-	CACHE
-	STRING
-	"Compiler options when Classic Flang compiler detected"
-)
-
-# TODO: Next steps are to figure out the preprocessing stuff, and then try to
-# compile! If it works, we'll then create options for classic flang, then we'll
-# go about trying to add the special sauce for LLVM Flang
-
 ################################################################################
 #
-# New Sections
+# Setting up build target
 #
 ################################################################################
 
@@ -272,7 +229,6 @@ target_compile_options(snap
   	$<$<AND:$<Fortran_COMPILER_ID:Intel>,$<NOT:$<BOOL:${KNL}>>>:${SNAP_COMPILER_OPTIONS_IFORT}>
   	$<$<AND:$<Fortran_COMPILER_ID:Intel>,$<BOOL:${KNL}>>:${SNAP_COMPILER_OPTIONS_IFORT_KNL}>
 		$<$<Fortran_COMPILER_ID:IntelLLVM>:${SNAP_COMPILER_OPTIONS_IFX}>
-		$<$<Fortran_COMPILER_ID:Flang>:${SNAP_COMPILER_OPTIONS_CLASSIC_FLANG}>
 )
 target_compile_definitions(snap
 	PRIVATE
@@ -295,12 +251,10 @@ target_link_libraries(snap
 # create line counting functionality
 add_custom_target(
 	count
-	#ALL
 	DEPENDS
 		Lines
 )
-#set(ENV{__SNAP_SRC_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-#message(STATUS "env var __SNAP_SRC_DIR - $ENV{__SNAP_SRC_DIR}")
+
 add_custom_command(
 	OUTPUT
 		src_list.txt
@@ -348,11 +302,3 @@ add_custom_command(
 		cmake -E remove ${CMAKE_CURRENT_BINARY_DIR}/src_list.txt
 	VERBATIM
 )
-# TODO: create a custom target to do this line counting operation from Makefile
-## Count lines of code
-#count:
-#	rm -f Lines
-#	for file in $(SRCS); do ./LineCount $$file Lines; done
-#	awk -f ./LineReport < Lines >> Lines
-#	cat Lines
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,358 @@
+################################################################################
+#
+# CMakeLists.txt
+# 
+# Author: Anthony Cabrera:
+# Contact: cabreraam AT ieee DOT org
+# Description: CMakeLists.txt replacement for SNAP Makefile
+#
+################################################################################
+
+#cmake_minimum_required(VERSION 3.18)
+
+#project(snap_test)
+
+#enable_language(Fortran)
+
+################################################################################
+#
+# Options and Variables
+#
+################################################################################
+
+
+option(MPI "Use MPI" OFF)
+option(OPT "Turn on optimizations" ON)
+option(OPENMP "Enable OpenMP" OFF)
+option(KNL "Intel KNL target" OFF)
+option(HASWELL "Does the CPU use the Haswell u-arch" OFF)
+option(CRAY "Is the target system a Cray?" OFF)
+
+if(MPI)
+	find_package(MPI REQUIRED)
+	message(STATUS "MPI_Fortran_COMPILER - ${MPI_Fortran_COMPILER}")
+	message(STATUS "MPI_Fortran_COMPILE_OPTIONS - ${MPI_Fortran_COMPILE_OPTIONS}")
+	message(STATUS "MPI_Fortran_COMPILE_DEFINITIONS - ${MPI_Fortran_COMPILE_DEFINITIONS}")
+	message(STATUS "MPI_Fortran_INCLUDE_DIRS - ${MPI_Fortran_INCLUDE_DIRS}")
+	message(STATUS "MPI_Fortran_LINK_FLAGS - ${MPI_Fortran_LINK_FLAGS}")
+	message(STATUS "MPI_Fortran_LIB_NAMES - ${MPI_Fortran_LIB_NAMES}")
+	message(STATUS "MPI_Fortran_LIBRARY - ${MPI_Fortran_LIBRARY}")
+	message(STATUS "MPI_Fortran_LIBRARIES - ${MPI_Fortran_LIBRARIES}")
+endif()
+
+if(OPENMP)
+	find_package(OpenMP REQUIRED)
+	message(STATUS "OpenMP_VERSION - ${OpenMP_VERSION}")
+	message(STATUS "OpenMP_Fortran_FOUND - ${OpenMP_Fortran_COMPILE_OPTIONS}")
+	message(STATUS "OpenMP_Fortran_FLAGS - ${OpenMP_Fortran_COMPILE_DEFINITIONS}")
+	message(STATUS "OpenMP_Fortran_INCLUDE_DIRS - ${OpenMP_Fortran_INCLUDE_DIRS}")
+	message(STATUS "OpenMP_Fortran_LINK_FLAGS - ${OpenMP_Fortran_LINK_FLAGS}")
+	message(STATUS "OpenMP_Fortran_LIB_NAMES - ${OpenMP_Fortran_LIB_NAMES}")
+	message(STATUS "OpenMP_Fortran_LIBRARY - ${OpenMP_Fortran_LIBRARY}")
+	message(STATUS "OpenMP_Fortran_LIBRARIES - ${OpenMP_Fortran_LIBRARIES}")
+	message(STATUS "OpenMP_HOME - ${OpenMP_HOME}")
+endif()
+
+#set(MPI "" CACHE STRING "Configure MPI")
+#set(FFLAGS "" CACHE STRING "Fortran flags")
+#set(FFLAG2 "" CACHE STRING "Fortran flags 2?")
+#set(DEFS "" CACHE STRING "Compiler definitions")
+#set(PPFLAGS "" CACHE STRING "Preprocessor flags?")
+#set(FORTRAN "" CACHE STRING "Fortran compiler")
+
+# Compiler Preprocessor Definitions
+# These should be passed in at the command line as a semi-colon-separated list
+# If the developer wants MPI, it would be set here
+# e.g., MPI + other pound define --> -DUSER_DEFS="MPI;OTHER_VAR;OTHER_VAR2=1"
+set(USER_DEFS "" CACHE STRING "Semi-colon separted preprocessor pound defines")
+
+
+################################################################################
+#
+# Compile Options for Different Compilers
+#
+################################################################################
+
+# Compile Options for GNU
+set(SNAP_COMPILER_OPTIONS_GNU_OPT
+	"-O3" 
+	CACHE 
+	STRING 
+	"GNU compiler options when OPT=ON"
+)
+set(SNAP_COMPILER_OPTIONS_GNU_NOT_OPT
+	"-O0"
+	"-g"
+	"-fbounds-check"
+	"-fbacktrace"
+	CACHE 
+	STRING 
+	"GNU compiler options when OPT=OFF"
+)
+set(SNAP_COMPILER_OPTIONS_GNU
+	$<$<BOOL:${OPENMP}>:-fopenmp>
+	$<IF:$<BOOL:${OPT}>,${SNAP_COMPILER_OPTIONS_GNU_OPT},${SNAP_COMPILER_OPTIONS_GNU_NOT_OPT}>
+	CACHE
+	STRING
+	"Compiler options when GNU compiler detected"
+)
+
+# Compile Options for ifort 
+set(SNAP_COMPILER_OPTIONS_IFORT_OPT
+	"-O3"
+	"-ip"
+	"-align array32byte"
+	"-qno-opt-dynamic-align"
+	"-fno-fnalias"
+	"-fp-model fast"
+	"-fp-speculation fast"
+	CACHE 
+	STRING 
+	"ifort compiler options when OPT=ON"
+)
+set(SNAP_COMPILER_OPTIONS_INTEL_NOT_OPT
+	"-O0"
+	"-g "
+	"-check bounds"
+	"-traceback"
+	"-warn unused"
+	CACHE 
+	STRING 
+	"ifort compiler options when OPT=OFF"
+)
+set(SNAP_COMPILER_OPTIONS_IFORT
+	$<$<BOOL:${OPENMP}>:-qopenmp>
+	$<IF:$<BOOL:${OPT}>,${SNAP_COMPILER_OPTIONS_IFORT_OPT},${SNAP_COMPILER_OPTIONS_INTEL_NOT_OPT}>
+	$<IF:$<BOOL:${HASWELL}>,"-xcore-avx2","-xHost">
+	CACHE
+	STRING
+	"Compiler options when ifort compiler detected"
+)
+
+# Compile Options for ifort knl
+set(SNAP_COMPILER_OPTIONS_IFORT_KNL_OPT
+	"-O3"
+	"-xmic-avx512"
+	"-ip"
+	"-align array64byte"
+	"-qno-opt-dynamic-align"
+	"-fp-model fast"
+	"-fp-speculation fast"
+	"-fno-alias -fno-fnalias"
+	CACHE 
+	STRING 
+	"ifort compiler options when OPT=ON and KNL=ON"
+)
+# This is the same as SNAP_COMPILER_OPTIONS_INTEL_NOT_OPT
+#set(SNAP_COMPILER_OPTIONS_IFORT_KNL_NOT_OPT
+#)
+set(SNAP_COMPILER_OPTIONS_IFORT_KNL
+	$<$<BOOL:${OPENMP}>:-qopenmp>
+	$<IF:$<BOOL:${OPT}>,${SNAP_COMPILER_OPTIONS_IFORT_KNL_OPT},${SNAP_COMPILER_OPTIONS_INTEL_NOT_OPT}>
+	CACHE
+	STRING
+	"Compiler options when ifort + knl compiler detected"
+)
+
+# Compile Options for intel ifx
+set(SNAP_COMPILER_OPTIONS_IFX_OPT
+	"-xcore-avx2"
+	"-Ofast"
+	"-funroll-loops"
+	"-nostandard-realloc-lhs"
+	"-align array32byte"
+	CACHE 
+	STRING 
+	"ifx compiler options when OPT=ON"
+)
+# This is the same as SNAP_COMPILER_OPTIONS_INTEL_NOT_OPT
+#set(SNAP_COMPILER_OPTIONS_IFX_OPT
+#)
+set(SNAP_COMPILER_OPTIONS_IFX
+	$<$<BOOL:${OPENMP}>:-fiopenmp>
+	$<IF:$<BOOL:${OPT}>,${SNAP_COMPILER_OPTIONS_IFX_OPT},${SNAP_COMPILER_OPTIONS_INTEL_NOT_OPT}>
+	CACHE
+	STRING
+	"Compiler options when ifx compiler detected"
+)
+
+# Compile Options for Classic Flang
+# TODO: What would the actual flags be for Classic Flang?
+set(SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_OPT
+	"-O3" 
+	CACHE 
+	STRING 
+	"Classic Flang compiler options when OPT=ON"
+)
+set(SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_NOT_OPT
+	"-O0"
+	"-g "
+	"-check bounds"
+	"-traceback"
+	"-warn unused"
+	CACHE 
+	STRING 
+	"Classic Flang compiler options when OPT=OFF"
+)
+set(SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_OPT
+	$<$<BOOL:${OPENMP}>:-fopenmp>
+	$<IF:$<BOOL:${OPT}>,${SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_OPT},${SNAP_COMPILER_OPTIONS_CLASSIC_FLANG_OPT}>
+	CACHE
+	STRING
+	"Compiler options when Classic Flang compiler detected"
+)
+
+# TODO: Next steps are to figure out the preprocessing stuff, and then try to
+# compile! If it works, we'll then create options for classic flang, then we'll
+# go about trying to add the special sauce for LLVM Flang
+
+################################################################################
+#
+# New Sections
+#
+################################################################################
+
+set(SNAP_SOURCE_FILES
+	global.f90
+	snap_main.f90
+	utils.f90
+	version.f90
+	plib.F90
+	geom.f90
+	sn.f90
+	data.f90
+	control.f90
+	input.f90
+	setup.f90
+	dealloc.f90
+	translv.f90
+	solvar.f90
+	outer.f90
+	expxs.f90
+	inner.f90
+	sweep.f90
+	octsweep.f90
+	dim1_sweep.f90
+	dim3_sweep.f90
+	output.f90
+	time.F90
+	mms.f90
+	analyze.f90
+	thrd_comm.f90
+	mkba_sweep.f90
+	CACHE
+	STRING
+	"List of SNAP source files"
+)
+
+# Handle files that need to be proprocessed, i.e., files with .F90 and NOT .f90
+set(SNAP_SOURCE_FILES_TO_PREPROC ${SNAP_SOURCE_FILES})
+list(FILTER SNAP_SOURCE_FILES_TO_PREPROC INCLUDE REGEX .*\.F90)
+set(SNAP_SOURCE_FILES_TO_PREPROC 
+	${SNAP_SOURCE_FILES_TO_PREPROC}
+	CACHE
+	STRING
+	"List of SNAP source files to preprocess"
+)
+set_source_files_properties(
+	${SNAP_SOURCE_FILES_TO_PREPROC}
+	PROPERTIES
+		Fortran_PREPROCESS ON
+)
+
+add_executable(snap)
+target_sources(snap
+	PRIVATE
+		${SNAP_SOURCE_FILES}
+)
+
+target_compile_options(snap 
+	PRIVATE
+		$<$<Fortran_COMPILER_ID:GNU>:${SNAP_COMPILER_OPTIONS_GNU}>
+  	$<$<AND:$<Fortran_COMPILER_ID:Intel>,$<NOT:$<BOOL:${KNL}>>>:${SNAP_COMPILER_OPTIONS_IFORT}>
+  	$<$<AND:$<Fortran_COMPILER_ID:Intel>,$<BOOL:${KNL}>>:${SNAP_COMPILER_OPTIONS_IFORT_KNL}>
+		$<$<Fortran_COMPILER_ID:IntelLLVM>:${SNAP_COMPILER_OPTIONS_IFX}>
+		$<$<Fortran_COMPILER_ID:Flang>:${SNAP_COMPILER_OPTIONS_CLASSIC_FLANG}>
+)
+target_compile_definitions(snap
+	PRIVATE
+		${USER_DEFS}
+		$<$<AND:$<BOOL:${MPI}>,$<BOOL:${CRAY}>>:MPI>
+		$<$<BOOL:${OPENMP}>:OPENMP>
+)
+# -I$(MPICH_DIR)/include
+target_include_directories(snap
+	PRIVATE
+		$<$<AND:$<BOOL:${MPI}>,$<BOOL:${CRAY}>>:${MPI_Fortran_INCLUDE_DIRS}>
+		$<$<BOOL:${OPENMP}>:${OpenMP_Fortran_INCLUDE_DIRS}>
+)
+target_link_libraries(snap
+	PRIVATE
+		$<$<AND:$<BOOL:${MPI}>,$<BOOL:${CRAY}>>:MPI::MPI_Fortran>
+		$<$<BOOL:${OPENMP}>:${OpenMP_Fortran_LIBRARIES}>
+)
+
+# create line counting functionality
+add_custom_target(
+	count
+	#ALL
+	DEPENDS
+		Lines
+)
+#set(ENV{__SNAP_SRC_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+#message(STATUS "env var __SNAP_SRC_DIR - $ENV{__SNAP_SRC_DIR}")
+add_custom_command(
+	OUTPUT
+		src_list.txt
+	DEPENDS
+		${SNAP_SOURCE_FILES}
+	COMMAND
+		cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/src_list.txt
+	COMMAND
+		echo ${SNAP_SOURCE_FILES} > ${CMAKE_CURRENT_BINARY_DIR}/src_list.txt
+	COMMENT
+		"Generate source file list lines of code"
+	VERBATIM
+)
+add_custom_command(
+	OUTPUT
+		Lines
+	DEPENDS
+		src_list.txt
+	COMMAND
+		cmake -E copy 
+			${CMAKE_CURRENT_SOURCE_DIR}/LineCount	
+			${CMAKE_CURRENT_BINARY_DIR}/LineCount
+	COMMAND
+		cmake -E copy 
+			${CMAKE_CURRENT_SOURCE_DIR}/LineReport	
+			${CMAKE_CURRENT_BINARY_DIR}/LineReport
+	COMMAND
+		cmake -E remove ${CMAKE_CURRENT_BINARY_DIR}/Lines
+	COMMAND
+		cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/Lines
+	COMMAND
+		cmake -E cat ${CMAKE_CURRENT_BINARY_DIR}/src_list.txt
+	COMMAND
+	#bash -c "while read file; do for word in $file; do ./LineCount $file Lines; done"
+	bash -c "while read line; do \
+			for file in $line; do \
+				${CMAKE_CURRENT_BINARY_DIR}/LineCount ${CMAKE_CURRENT_SOURCE_DIR}/$file	${CMAKE_CURRENT_BINARY_DIR}/Lines; \
+			done; \
+		done < '${CMAKE_CURRENT_BINARY_DIR}/src_list.txt'" 
+	COMMAND
+		awk -f ${CMAKE_CURRENT_BINARY_DIR}/LineReport < ${CMAKE_CURRENT_BINARY_DIR}/Lines >> ${CMAKE_CURRENT_BINARY_DIR}/Lines
+	COMMAND
+		cmake -E cat ${CMAKE_CURRENT_BINARY_DIR}/Lines
+	COMMAND
+		cmake -E remove ${CMAKE_CURRENT_BINARY_DIR}/src_list.txt
+	VERBATIM
+)
+# TODO: create a custom target to do this line counting operation from Makefile
+## Count lines of code
+#count:
+#	rm -f Lines
+#	for file in $(SRCS); do ./LineCount $$file Lines; done
+#	awk -f ./LineReport < Lines >> Lines
+#	cat Lines
+


### PR DESCRIPTION
Hello SNAP devs,

Out of a need to build SNAP with CMakeLists.txt for a different project (directly related to #19), I have implemented CMake build infrastructure for SNAP. In using modern CMake, I tried as much as possible to make it the CMakeLists.txt file easy to understand for folks who are used to the `Make` build infrastructure. Credit to @banach-space for helping stir me into using modern CMake constructs.

Here are some of the salient features of my CMake contribution:

1. Instead of having different build targets for different compilers, e.g., `gsnap`, `isnap`, there is a single build target called `snap`. The idea now would that developers would create a different build directory each time they wanted to try out a new compiler, e.g., `build_gnu`.

An example build may take on the following form, as given in a bash script:

```
#!/usr/bin/env bash

mkdir -p build_gnu
cd build_gnu

# mpifort doesn't set all of the MPI_Fortran_* stuff
# As long as we specify MPI, all of the MPI_Fortran_* stuff gets set
CMAKE_OPTIONS="-DCMAKE_Fortran_COMPILER=gfortran \
        -DOPENMP=ON \
        -DMPI=ON \
        -DOPT=ON \
        -DCRAY=ON \
"

cmake ${CMAKE_OPTIONS} ..
make VERBOSE=1 -j4
```

2. The build options specified by the original Makefile all exist in the CMakeLists.txt files. As shown above in the script, they should be passed in as CMake build options. Of note is the `CRAY` variable. In the original makefile, information for MPI include and library directories are only passed if MPI is set to "cray". I've honored that in my Makefile, but the way I've written it, developers should specify `-DCRAY=ON` for now, in order to pass include and library directories for MPI.

3. There is a custom target called `count` which is equivalent to the original Makefile target `count`.

I've tested with both Make and Ninja as generators.

I would appreciate if y'all would test my contribution to see if it's worth adding.



Thanks!
Anthony
