### PR TITLE
Make the build system work on macOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -173,8 +173,8 @@ translv.o :	global.o plib.o geom.o sn.o data.o control.o utils.o \
 # Fortran rules
 #
 %.o:	%.F90
-	$(PP) -P $(PPFLAGS) $< >$*.f90
-	$(FORTRAN) $(FFLAGS) -c $*.f90
+	$(PP) -P $(PPFLAGS) $< >$*.0.f90
+	$(FORTRAN) $(FFLAGS) -c $*.0.f90 -o $*.o
 
 %.o:	%.f90
 	$(FORTRAN) $(FFLAGS) -c $<


### PR DESCRIPTION
The original file has extension `.F90`, the generated file changes the extension to `.f90`, which works on Linux. However on macOS due to the case-preserving filesystem it fails. The fix is to rename the generated file, then it works on both Linux and macOS.